### PR TITLE
test: add test coverage with karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,7 @@
 const packageJson = require('./package.json');
 const path = require('path');
+const browserifyIstanbul = require('browserify-istanbul');
+const isparta = require('isparta');
 const oneSecondInMilliseconds = 1000;
 const oneMinuteInSeconds = 60;
 const twoMinutesInMilliseconds = oneSecondInMilliseconds * oneMinuteInSeconds * 2;
@@ -45,13 +47,15 @@ module.exports = function configureKarma(config) {
     basePath: '',
     browsers: localBrowsers,
     logLevel: config.LOG_INFO,
-    frameworks: [ 'mocha' ],
+    frameworks: [ 'browserify', 'mocha' ],
     files: [
-      path.join(packageJson.directories.site, 'bundle.js'),
+      path.join(packageJson.directories.test, '*.js'),
     ],
     exclude: [],
-    preprocessors: {},
-    reporters: [ 'mocha' ],
+    preprocessors: {
+      [path.join(packageJson.directories.test, '*.js')]: [ 'browserify' ],
+    },
+    reporters: [ 'mocha', 'coverage' ],
     port: 9876,
     colors: true,
     concurrency: 3,
@@ -60,6 +64,19 @@ module.exports = function configureKarma(config) {
     browserDisconnectTimeout: twoMinutesInMilliseconds,
     browserNoActivityTimeout: twoMinutesInMilliseconds,
     singleRun: true,
+    browserify: {
+      transform: [
+        browserifyIstanbul({
+          instrumenter: isparta,
+          ignore: [ '**/node_modules/**', '**/test/**' ],
+        }),
+        'babelify',
+      ],
+    },
+    coverageReporter: {
+      type: 'lcov',
+      dir: 'coverage',
+    },
   });
 
   if (process.env.SAUCE_ACCESS_KEY && process.env.SAUCE_USERNAME) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build": "npm-run-all --parallel build:*",
     "prebuild:css": "mkdir -p $npm_package_directories_lib",
     "build:css": "cp $npm_package_directories_src/*.css $npm_package_directories_lib",
-    "build:js": "babel $npm_package_directories_src -d $npm_package_directories_lib",
+    "build:js": "babel $npm_package_directories_src -d $npm_package_directories_lib --source-maps inline",
     "ci": "sh ./build.sh",
     "predoc": "mkdir -p $npm_package_directories_site",
     "doc": "npm-run-all --parallel doc:*",
@@ -70,7 +70,7 @@
   "config": {
     "doc": {
       "js": {
-        "options": "-r react -r react-dom -r ./src/example.js:example"
+        "options": "-d -r react -r react-dom -r ./src/example.js:example"
       },
       "html": {
         "files": "@economist/doc-pack/templates/index.hbs @economist/doc-pack/templates/standalone.hbs"
@@ -93,7 +93,6 @@
     "compact": false,
     "ignore": "node_modules",
     "loose": "all",
-    "sourceMaps": "inline",
     "stage": 2
   },
   "eslintConfig": {
@@ -126,6 +125,7 @@
     "babel-polyfill": "^6.6.1",
     "babelify": "^6.4.0",
     "browserify": "^13.0.0",
+    "browserify-istanbul": "^1.0.0",
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "eslint": "^2.3.0",
@@ -137,6 +137,8 @@
     "git-directory-deploy": "^1.5.0",
     "hbs-cli": "^1.0.0",
     "karma": "^0.13.21",
+    "karma-browserify": "^5.0.2",
+    "karma-coverage": "^0.5.5",
     "karma-mocha": "^0.2.2",
     "karma-mocha-reporter": "^2.0.0",
     "karma-phantomjs-launcher": "^1.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill';
-import BlogPost from '..';
-import React from 'react/addons';
+import BlogPost from '../src';
+import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import chai from 'chai';
 chai.should();


### PR DESCRIPTION
Test coverage provided by `isparta`, configuration mostly taken from 

- https://github.com/keithamus/type-detect/blob/giant-refactor/karma.conf.js
- https://github.com/kt3k/karma-browserify-isparta-example/blob/master/karma.conf.js

`sourceMaps`in the `babel` config were set to `false` because of this bug https://github.com/webpack/webpack/issues/1071