### PR TITLE
feat: TEC-1213: laying out images according to their aspect (slim/wide)

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,8 @@
     "react-addons-test-utils": "^0.14.8||^15.0.0",
     "react-dom": "^0.14.8||^15.0.0",
     "semantic-release": "^4.3.5",
+    "sinon": "^1.17.4",
+    "sinon-chai": "^2.8.0",
     "stylelint": "^6.3.3",
     "stylelint-config-strict": "^5.0.0",
     "travis-after-all": "^1.4.4",

--- a/src/index.css
+++ b/src/index.css
@@ -193,17 +193,12 @@
   border-bottom: 1px solid var(--color-berlin);
 }
 
-
-.blog-post__inline-image--generic {
-  text-align: center;
-}
-
 .blog-post-article-image {
   width: 100%;
   height: auto;
 }
 
-.blog-post-article-image.image-type__slim {
+.blog-post-article-image__slim {
   width: auto;
   max-width: 100%;
 }
@@ -213,7 +208,7 @@
   .blog-post__inline-image--generic {
     float: left;
   }
-  .blog-post-article-image.image-type__slim {
+  .blog-post-article-image__slim {
     max-width: var(--slim-max-width);
     margin-right: var(--slim-margin);
   }

--- a/src/index.css
+++ b/src/index.css
@@ -214,7 +214,6 @@
     float: left;
   }
   .blog-post-article-image.image-type__slim {
-    float: left;
     max-width: var(--slim-max-width);
     margin-right: var(--slim-margin);
   }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+/* stylelint-disable selector-no-type */
+/* unknown class */
+
 @import '@economist/component-typography';
 @import '@economist/component-palette';
 @import '@economist/component-grid';
@@ -5,6 +8,11 @@
 @import 'settings.css';
 @import 'sharebar.css';
 @import 'comments.css';
+
+:root {
+  --slim-max-width: 290px;
+  --slim-margin: 30px;
+}
 
 .blog-post {
   font-family: var(--fontfamily-sans);
@@ -100,15 +108,10 @@
   line-height: var(--text-line-height-sans-on-step--2);
 }
 
-/* stylelint-disable selector-no-type */
-/* unknown class */
-
 .blog-post__section-link, .blog-post__text a {
   transition: color 101ms ease;
   transition-property: color, border-bottom-color;
 }
-
-/* stylelint-enable selector-no-type */
 
 .blog-post__section-link {
   color: var(--blog-post-color-section-link, inherit);
@@ -122,9 +125,6 @@
 .blog-post__section-link:visited {
   color: inherit;
 }
-
-/* stylelint-disable selector-no-type */
-/* unknown class */
 
 .blog-post__text a {
   color: var(--blog-post-color-link-underline, inherit);
@@ -180,8 +180,6 @@
   margin-top: 0.2em;
 }
 
-/* stylelint-enable selector-no-type */
-
 .blog-post__inner {
   position: relative;
 }
@@ -193,6 +191,33 @@
   justify-content: space-between;
   border-top: 1px solid var(--color-berlin);
   border-bottom: 1px solid var(--color-berlin);
+}
+
+
+.blog-post__inline-image--generic {
+  text-align: center;
+}
+
+.blog-post-article-image {
+  width: 100%;
+  height: auto;
+}
+
+.blog-post-article-image.image-type__slim {
+  width: auto;
+  max-width: 100%;
+}
+
+
+@media (--fe-blogs-small-layout) {
+  .blog-post__inline-image--generic {
+    float: left;
+  }
+  .blog-post-article-image.image-type__slim {
+    float: left;
+    max-width: var(--slim-max-width);
+    margin-right: var(--slim-margin);
+  }
 }
 
 @media (--navigation-big-desktop-up) {
@@ -207,3 +232,4 @@
     border-bottom: 1px solid var(--color-berlin);
   }
 }
+

--- a/src/parts/article-image.js
+++ b/src/parts/article-image.js
@@ -1,0 +1,71 @@
+import React from 'react';
+
+/**
+ * This component models an inline image occurring within an article
+ **/
+class ArticleImage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleImageLoaded = this.handleImageLoaded.bind(this);
+    this.state = {
+      aspectType: 'normal',
+      aspectRecomputed: false,
+    };
+  }
+
+  componentWillMount() {
+    const { width = '0', height = '0' } = this.props;
+    // if the image has already got dimension attrs, we can immediately apply
+    // the aspect adjustments (if any)
+    const nWidth = parseInt(width, 10) || 0;
+    const nHeight = parseInt(height, 10) || 0;
+    if (nWidth && nHeight) {
+      this.applyImageAspect(nWidth, nHeight);
+      // setting the state as recomputed will avoid unnecessary recomputations when
+      // the image is loaded
+      this.setState({ aspectRecomputed: true });
+    }
+  }
+
+  handleImageLoaded() {
+    // if the aspect recomputation has been already done,
+    // just return.
+    if (this.state.aspectRecomputed) {
+      return;
+    }
+    this.applyImageAspect(this.refs.image.naturalWidth, this.refs.image.naturalHeight);
+  }
+
+  applyImageAspect(width, height) {
+    // if the image is taller than wider, then it's a slim one
+    if (height > width) {
+      // tag the image as 'slim'
+      this.setState({ aspectType: 'slim', aspectRecomputed: true });
+    }
+  }
+
+  render() {
+    const { className = '' } = this.props;
+    const imageClass = `${ className } blog-post-article-image image-type__${ this.state.aspectType }`;
+    return (
+      <img
+        ref="image"
+        className={imageClass}
+        {...this.props}
+        onLoad={this.handleImageLoaded}
+      />
+    );
+  }
+}
+
+
+ArticleImage.propTypes = {
+  alt: React.PropTypes.string,
+  caption: React.PropTypes.element,
+  src: React.PropTypes.string.isRequired,
+  width: React.PropTypes.string,
+  height: React.PropTypes.string,
+  className: React.PropTypes.string,
+};
+
+export default ArticleImage;

--- a/src/parts/article-image.js
+++ b/src/parts/article-image.js
@@ -46,7 +46,7 @@ class ArticleImage extends React.Component {
 
   render() {
     const { className = '' } = this.props;
-    const imageClass = `${ className } blog-post-article-image image-type__${ this.state.aspectType }`;
+    const imageClass = `${ className } blog-post-article-image blog-post-article-image__${ this.state.aspectType }`;
     return (
       <img
         ref="image"

--- a/test/index.js
+++ b/test/index.js
@@ -262,45 +262,31 @@ describe('BlogPost', () => {
   });
 
   describe('images', () => {
-    /* eslint-disable max-len */
-    const wideExplicit = `
-      <p class="xhead">Wide image with explicit measures</p>
-      <p>The following image is a "wide" one. the HTML image tag comes with <em>width</em> and <em>height</em> already specified, so we just take them for true and we determine if the image is wide or slim based on those values</p>
-      <figure>
-        <img id="wide-explicit" src="http://cdn.static-economist.com/sites/default/files/images/2016/05/articles/body/20160528_IRC476.png" alt="" title="" height="732" width="1190"/>
-      </figure>
-    `;
-    const textIntro = `
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    `;
-    const textOuttro = `
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    `;
-    const slimExplicit = `
-      <p class="xhead">Slim image with explicit measures</p>
-      <p>The following image is a 'slim' one and its dimensions are provided by the HTML content, so we just use them to determine its aspect and style it accordingly. we have also some additional text to flow around it:</p>
-      <figure>
-        <img id="slim-explicit" src="http://cdn.static-economist.com/sites/default/files/images/2016/07/articles/body/20160709_brp006.jpg" alt="" title="" height="317" width="290"/>
-      </figure>
-    `;
-    /* eslint-enable max-len */
     // subject under test
     let subject = null;
 
     it('tags wide images according to their attributed measures', () => {
-      subject = mountComponentWithProps({
-        text: textIntro + wideExplicit + textOuttro
+      subject = new ArticleImage({
+        src:"http://cdn.static-economist.com/sites/default/files/images/2016/07/articles/body/20160709_brp006.jpg",
+        width: "1090",
+        height: "450"
       });
-      // check that the image is marked as 'image-type__normal'
-      subject.find('#wide-explicit.image-type__normal').should.not.be.null;
+      subject.setState = sinon.spy();
+      subject.componentWillMount();
+      // check that the image is marked as 'normal'
+      subject.setState.should.have.been.calledWith({ aspectRecomputed: true });
     });
 
     it('tags slim images according to their attributed measures', () => {
-      subject = mountComponentWithProps({
-        text: textIntro + slimExplicit + textOuttro
+      subject = new ArticleImage({
+        src:"http://cdn.static-economist.com/sites/default/files/images/2016/07/articles/body/20160709_brp006.jpg",
+        width: "290",
+        height: "450"
       });
-      // check that the image is marked as 'image-type__slim'
-      subject.find('#slim-explicit.image-type__slim').should.not.be.null;
+      subject.setState = sinon.spy();
+      subject.componentWillMount();
+      // check that the image is marked as 'slim'
+      subject.setState.should.have.been.calledWith({ aspectType: 'slim', aspectRecomputed: true });
     });
 
     it('tags wide images with no measures according to their aspect', () => {


### PR DESCRIPTION
Adding a new component 'ArticleImage'.
This component models the images present in the article content (the interception and mapping between the img tags and the React component is done in blog-post.js in fe-blogs). 
The image component set itself to 'normal' or 'slim' depending on the size information coming from the HTML tag attributes or (in their absence) from the natural width/height of the image itself. 