### PR TITLE
fix: TEC-1177: Fixing correct margins for wide-but-slim inline images

### DIFF
--- a/src/parts/article-image.js
+++ b/src/parts/article-image.js
@@ -2,6 +2,9 @@ import React from 'react';
 
 /**
  * This component models an inline image occurring within an article
+ * 2016.07.18: fix/1177: 'Slim' images can also have a 'wide' aspect (W > H) but still being 'small' in size (290px)
+ *    For this reason we've to account for exceptions:
+ *     - slim images: images where H > W OR W = 290px
  **/
 class ArticleImage extends React.Component {
   constructor(props) {
@@ -36,9 +39,20 @@ class ArticleImage extends React.Component {
     this.applyImageAspect(this.refs.image.naturalWidth, this.refs.image.naturalHeight);
   }
 
+  /**
+   * Images with a specific stated width are automatically detected as 'slim', no
+   * matter what aspect they might have...
+   **/
+  hasSlimOverride(width) {
+    /* eslint-disable no-magic-numbers */
+    const slimOverrides = [ 290 ];
+    /* eslint-enable no-magic-numbers */
+    return slimOverrides.indexOf(width) >= 0;
+  }
+
   applyImageAspect(width, height) {
     // if the image is taller than wider, then it's a slim one
-    if (height > width) {
+    if (this.hasSlimOverride(width) || height > width) {
       // tag the image as 'slim'
       this.setState({ aspectType: 'slim', aspectRecomputed: true });
     }

--- a/test/index.js
+++ b/test/index.js
@@ -348,6 +348,20 @@ describe('BlogPost', () => {
       subject.handleImageLoaded();
       subject.applyImageAspect.should.not.have.been.called;
     });
+
+    it('overrides normal rules for specific image widths (implicit or explicit)', () => {
+      // the following image should be considered a 'wide' one, but because of slim overrides,
+      // it will be considered 'slim'
+      subject = new ArticleImage({
+        src:"someimage.jpg"
+      });
+
+      subject.setState = sinon.spy();
+      subject.applyImageAspect(290, 100)
+      subject.setState.should.have.been.calledWith({ aspectType: 'slim', aspectRecomputed: true });
+      subject.applyImageAspect(580, 100)
+      subject.setState.should.have.been.calledWith({ aspectType: 'slim', aspectRecomputed: true });
+    });
   });
 });
 


### PR DESCRIPTION
Part of TEC-1177.
small inline images with a 'wide' aspect were showing up without the correct gutters.
That was coherent with the way we currently identify 'wide' and 'slim' inline images.
In order to fix the issue, we've to apply an override for images that, albeit wide in aspect, need to be treated as slim ones (so, floating AND with gutter).