### PR TITLE
fix: TEC-1177: consider images as wide when specific width are matched

### DIFF
--- a/src/parts/article-image.js
+++ b/src/parts/article-image.js
@@ -5,6 +5,7 @@ import React from 'react';
  * 2016.07.18: fix/1177: 'Slim' images can also have a 'wide' aspect (W > H) but still being 'small' in size (290px)
  *    For this reason we've to account for exceptions:
  *     - slim images: images where H > W OR W = 290px OR W = 580px
+ *     - wide images: images where W > H OR W = 595px OR W = 1190px
  **/
 class ArticleImage extends React.Component {
   constructor(props) {
@@ -50,7 +51,18 @@ class ArticleImage extends React.Component {
     return slimOverrides.indexOf(width) >= 0;
   }
 
+  hasWideOverride(width) {
+    /* eslint-disable no-magic-numbers */
+    const wideOverrides = [ 595, 1190 ];
+    /* eslint-enable no-magic-numbers */
+    return wideOverrides.indexOf(width) >= 0;
+  }
+
   applyImageAspect(width, height) {
+    // if there's a wide override for this image, bail out
+    if (this.hasWideOverride(width)) {
+      return;
+    }
     // if the image is taller than wider, then it's a slim one
     if (this.hasSlimOverride(width) || height > width) {
       // tag the image as 'slim'

--- a/test/index.js
+++ b/test/index.js
@@ -359,8 +359,15 @@ describe('BlogPost', () => {
       subject.setState = sinon.spy();
       subject.applyImageAspect(290, 100)
       subject.setState.should.have.been.calledWith({ aspectType: 'slim', aspectRecomputed: true });
+      subject.setState.reset();
       subject.applyImageAspect(580, 100)
       subject.setState.should.have.been.calledWith({ aspectType: 'slim', aspectRecomputed: true });
+      subject.setState.reset();
+      subject.applyImageAspect(595, 900)
+      subject.setState.should.not.have.been.called;
+      subject.setState.reset();
+      subject.applyImageAspect(1190, 2900)
+      subject.setState.should.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
A quick additional fix.
This fix is for ALWAYS recognising images with width = 595/1190 as WIDE images, no matter which aspect ratio they  have (editorial rule).

This solve problems like the one here: http://www.economist.com/blogs/gametheory/2016/07/ranking-performances-golf?internalpreview=1
(The chart in the middle of the article is treated as a 'slim', inline, article.. but editorial rules want it to be considered WIDE (so, full width))
