### PR TITLE
fix: updated blog post header to be a h1 instead of h2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,7 @@ export default class BlogPost extends React.Component {
         role="article"
         ref="article"
       >
-        <TitleComponent title={this.props.title} flyTitle={this.props.flyTitle} />
+        <TitleComponent title={this.props.title} flyTitle={this.props.flyTitle} Heading={"h1"} />
         {content}
 
       </article>


### PR DESCRIPTION
In relation to TEC-1062 (https://jira.economist.com/browse/TEC-1062).
Needs merging so I can update FE-Blogs.