### PR TITLE
feat: TEC-1342: 

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -199,7 +199,6 @@
   }
   .blog-post-article-image__slim {
     margin-top: var(--slim-margin-top);
-    margin-right: var(--slim-margin);
   }
 }
 


### PR DESCRIPTION
making inline images flow nicely  even when below the minimum width.
This is to fix an issue with articles/posts containing very small inline images whose width < 290px.
These images are to be styles as 'slim' ones too.
We remove the margin we were using for the inline images. It will be handled in fe-blogs by the image container tag (the figure tag)