### PR TITLE
fix: WP-542 fixing problem with last inline mobile ad

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -242,12 +242,29 @@ export default class BlogPost extends React.Component {
     return blogPostTextElements;
   }
 
+  filterLastInlineAd(blogPostText) {
+    const regex = /inline-ad/;
+    const inlineAdIndexes = [];
+    if (blogPostText.constructor !== Array) {
+      return null;
+    }
+    blogPostText.forEach((element, i) => {
+      const className = element && element.props ? element.props.className : null;
+      if (className && className.match(regex)) {
+        inlineAdIndexes.push(i);
+      }
+      return i;
+    });
+    return inlineAdIndexes;
+  }
+
   moveBottomMobileAd(content) {
     const blogPostText = this.filterBlogPostTextElements(content);
-    const numberOfParagraphs = blogPostText.length;
-    const mobileAd = blogPostText[numberOfParagraphs - 1];
-    if (mobileAd) {
-      blogPostText.pop();
+    const inlineAdIndexes = blogPostText ? this.filterLastInlineAd(blogPostText) : null;
+    const lastInlineAdIndex = inlineAdIndexes ? inlineAdIndexes[inlineAdIndexes.length - 1] : null;
+    const mobileAd = lastInlineAdIndex ? blogPostText[lastInlineAdIndex] : null;
+    if (lastInlineAdIndex && mobileAd) {
+      blogPostText.splice(lastInlineAdIndex, 1);
       content.push(mobileAd);
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -223,6 +223,24 @@ describe('BlogPost', () => {
     post.find('.blog-post__text').should.have.exactly(1).descendants('.foo');
   });
 
+  it('moves the last inline out outside the text content and not the last paragraph', () => {
+    const text = [
+      <div key="1" className="paragraph">paragraph 1</div>,
+      <div key="2" className="inline-ad">inline advert 1</div>,
+      <div key="3" className="paragraph">paragraph 2</div>,
+      <div key="4" className="inline-ad">inline advert 2</div>
+    ]
+    const blogPostText = mountComponentWithProps({ text: text }).find('.blog-post__text');
+    blogPostText.should.have.exactly(2).descendants('.paragraph');
+    blogPostText.contains(
+      <div key="2" className="inline-ad">inline advert 1</div>
+    ).should.equal(true);
+    blogPostText.contains(
+      <div key="4" className="inline-ad">inline advert 2</div>
+    ).should.equal(false);
+  });
+
+
   it('renders an image', () => {
     const image = {
       src: '//cdn.static-economist.com/sites/all/themes/econfinal/images/svg/logo.svg',

--- a/test/index.js
+++ b/test/index.js
@@ -21,10 +21,10 @@ const requiredProps = {
   flyTitle: 'Required flyTitle',
   section: 'Required section',
   text: [
-    "paragraph 1 paragraph 1 paragraph 1",
-    "paragraph 2 paragraph 2 paragraph 2",
-    "paragraph 3 paragraph 3 paragraph 3",
-    "paragraph 4 paragraph 4 paragraph 4",
+    "paragraph 1",
+    "paragraph 2",
+    "paragraph 3",
+    "paragraph 4",
   ],
   title: 'Required title',
   type: 'blog',
@@ -44,10 +44,10 @@ const otherProps = {
   flyTitle: 'Other flyTitle',
   section: 'Other section',
   text: [
-    "paragraph 1 paragraph 1 paragraph 1",
-    "paragraph 2 paragraph 2 paragraph 2",
-    "paragraph 3 paragraph 3 paragraph 3",
-    "paragraph 4 paragraph 4 paragraph 4",
+    "paragraph 1",
+    "paragraph 2",
+    "paragraph 3",
+    "paragraph 4",
   ],
   title: 'Other title',
   type: 'blog',
@@ -100,7 +100,7 @@ describe('BlogPost', () => {
 
     it('renders a text', () => {
       post.should.have.exactly(1).descendants('.blog-post__text');
-      post.find('.blog-post__text').should.have.text(requiredProps.text);
+      post.find('.blog-post__text').should.have.text('paragraph 1paragraph 2paragraph 3paragraph 4');
     });
 
     it('renders the section name', () => {


### PR DESCRIPTION
There was a problem with the bottom mobile inline-advert on small articles with only a few paragraphs. The previous code was moving the inline ad at the bottom of the article to underneath the bottom share bar. However the code didn't check if it was an advert thus on small articles it moves the last paragraph out causing this problem (problem on left of image):
![inline-ad-problem](https://cloud.githubusercontent.com/assets/15678246/23702822/ddcf57f6-03f4-11e7-93a3-5d61beb072a4.png)
This PR fixes the problem with text being rendered underneath the bottom share bar in an article. I have added a check to filter for the last inline-ad and move that instead of whatever is in the last paragraph.
Can be tested on this article: /news/china/21701807-bigwig-purged