### PR TITLE
fix: adding ternary incase data doesn't exist to stop page crashing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,13 +232,13 @@ export default class BlogPost extends React.Component {
 
   filterBlogPostTextElements(content) {
     const innerContentElements = content.filter((contentElement) => {
-      const innerContent = contentElement ? contentElement.key === 'inner-content' : null;
+      const innerContent = contentElement && contentElement.key === 'inner-content';
       return innerContent;
     })[0].props.children;
-    const blogPostTextElements = innerContentElements ? (innerContentElements.filter((contentElement) => {
-      const blogPostText = contentElement ? contentElement.key === 'blog-post__text' : null;
+    const blogPostTextElements = innerContentElements.filter((contentElement) => {
+      const blogPostText = contentElement && contentElement.key === 'blog-post__text';
       return blogPostText;
-    })[0].props.text) : null;
+    })[0].props.text;
     return blogPostTextElements;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -232,13 +232,13 @@ export default class BlogPost extends React.Component {
 
   filterBlogPostTextElements(content) {
     const innerContentElements = content.filter((contentElement) => {
-      const innerContent = contentElement.key === 'inner-content';
+      const innerContent = contentElement ? contentElement.key === 'inner-content' : null;
       return innerContent;
     })[0].props.children;
-    const blogPostTextElements = innerContentElements.filter((contentElement) => {
-      const blogPostText = contentElement.key === 'blog-post__text';
+    const blogPostTextElements = innerContentElements ? (innerContentElements.filter((contentElement) => {
+      const blogPostText = contentElement ? contentElement.key === 'blog-post__text' : null;
       return blogPostText;
-    })[0].props.text;
+    })[0].props.text) : null;
     return blogPostTextElements;
   }
 


### PR DESCRIPTION
In some cases `contentElement` is null and so doesn't have a key. I have just added a ternary to check if the data exist first before filtering.