### PR TITLE
fix: WP-890 - article footnote rendering in all articles not just special reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
     "postcss-import": "^8.1.2",
     "postcss-reporter": "^1.3.3",
     "postcss-url": "^5.1.1",
-    "react-addons-create-fragment": "^15.4.2",
     "react-addons-test-utils": "^0.14.8||^15.0.0",
     "react-dom": "^0.14.8||^15.0.0",
     "semantic-release": "^4.3.5",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "postcss-import": "^8.1.2",
     "postcss-reporter": "^1.3.3",
     "postcss-url": "^5.1.1",
+    "react-addons-create-fragment": "^15.4.2",
     "react-addons-test-utils": "^0.14.8||^15.0.0",
     "react-dom": "^0.14.8||^15.0.0",
     "semantic-release": "^4.3.5",

--- a/src/index.js
+++ b/src/index.js
@@ -326,12 +326,6 @@ export default class BlogPost extends React.Component {
     }
   }
 
-  addArticleFootNote(blogPostText, articleFootNote) {
-    if (blogPostText && articleFootNote) {
-      blogPostText.push(articleFootNote);
-    }
-  }
-
   generateWrappedInnerContent(asideableContent) {
     let wrappedInnerContent = [];
     wrappedInnerContent = this.addImage(wrappedInnerContent, this.props.image);

--- a/src/index.js
+++ b/src/index.js
@@ -258,8 +258,7 @@ export default class BlogPost extends React.Component {
     return inlineAdIndexes;
   }
 
-  moveBottomMobileAd(content) {
-    const blogPostText = this.filterBlogPostTextElements(content);
+  moveBottomMobileAd(content, blogPostText) {
     const inlineAdIndexes = blogPostText ? this.filterLastInlineAd(blogPostText) : null;
     const lastInlineAdIndex = inlineAdIndexes ? inlineAdIndexes[inlineAdIndexes.length - 1] : null;
     const mobileAd = lastInlineAdIndex ? blogPostText[lastInlineAdIndex] : null;
@@ -272,17 +271,16 @@ export default class BlogPost extends React.Component {
   addSecondaryList(
     secondaryList,
     secondaryListPosition,
-    content,
-    showSiblingArticlesList
+    showSiblingArticlesList,
+    blogPostText
   ) {
     if (!secondaryList) {
       return null;
     }
-    const blogPostTextElements = this.filterBlogPostTextElements(content);
     /* eslint-disable arrow-body-style */
     let isEnoughParagraphs = null;
-    if (typeof blogPostTextElements[0] === 'object') {
-      isEnoughParagraphs = blogPostTextElements.find((element) => {
+    if (typeof blogPostText[0] === 'object') {
+      isEnoughParagraphs = blogPostText.find((element) => {
         /* eslint-enable arrow-body-style */
         return element.type === 'p';
       });
@@ -292,7 +290,7 @@ export default class BlogPost extends React.Component {
     }
     const alternateListPosition = 4;
     const position = showSiblingArticlesList ? secondaryListPosition + alternateListPosition : secondaryListPosition;
-    return blogPostTextElements.splice(position, 0, secondaryList);
+    return blogPostText.splice(position, 0, secondaryList);
   }
 
   addSiblingsList(siblingListProps) {
@@ -305,13 +303,14 @@ export default class BlogPost extends React.Component {
       issueSiblingsList,
       articleListPosition,
       nextArticleLink,
+      blogPostText,
     } = siblingListProps;
     if (!issueSiblingsList || !showSiblingArticlesList) {
       return;
     }
     const siblingArticles = showSiblingArticlesList && issueSiblingsList ?
     issueSiblingsList : null;
-    const { sideText, siblingListSideTitle, articleFootNote } = this.props;
+    const { sideText, siblingListSideTitle } = this.props;
     const siblingListData = {
       siblingArticles,
       flyTitle,
@@ -321,21 +320,15 @@ export default class BlogPost extends React.Component {
       siblingListSideTitle,
     };
     const siblingArticlesList = showSiblingArticlesList ? siblingList(siblingListData) : null;
-    let blogPostTextElements = null;
-    if (showSiblingArticlesList || articleFootNote) {
-      blogPostTextElements = this.filterBlogPostTextElements(content);
-    }
-    if (showSiblingArticlesList && (blogPostTextElements || (content && nextArticleLink))) {
-      blogPostTextElements.splice(articleListPosition, 0, siblingArticlesList);
+    if (showSiblingArticlesList && (blogPostText || (content && nextArticleLink))) {
+      blogPostText.splice(articleListPosition, 0, siblingArticlesList);
       content.splice(content.length - 1, 0, nextArticleLink);
     }
   }
 
-  addArticleFootNote(content, articleFootNote) {
-    let blogPostTextElements = null;
-    if (articleFootNote) {
-      blogPostTextElements = this.filterBlogPostTextElements(content);
-      blogPostTextElements.push(articleFootNote);
+  addArticleFootNote(blogPostText, articleFootNote) {
+    if (blogPostText && articleFootNote) {
+      blogPostText.push(articleFootNote);
     }
   }
 
@@ -461,9 +454,10 @@ export default class BlogPost extends React.Component {
         </div>
       </div>
     );
-    this.moveBottomMobileAd(content);
+    const blogPostText = this.filterBlogPostTextElements(content);
+    this.moveBottomMobileAd(content, blogPostText);
     if (printEdition && articleFootNote) {
-      this.addArticleFootNote(content, articleFootNote);
+      this.addArticleFootNote(blogPostText, articleFootNote);
     }
     const TitleComponent = this.props.TitleComponent;
     const articleHeader = showSiblingArticlesList ? (
@@ -481,13 +475,14 @@ export default class BlogPost extends React.Component {
       articleListPosition,
       nextArticleLink,
       printEdition,
+      blogPostText,
     };
     this.addSiblingsList(siblingListProps);
     this.addSecondaryList(
       secondaryList,
       secondaryListPosition,
-      content,
-      showSiblingArticlesList
+      showSiblingArticlesList,
+      blogPostText
     );
     return (
       <article

--- a/src/index.js
+++ b/src/index.js
@@ -305,7 +305,6 @@ export default class BlogPost extends React.Component {
       issueSiblingsList,
       articleListPosition,
       nextArticleLink,
-      printEdition,
     } = siblingListProps;
     if (!issueSiblingsList || !showSiblingArticlesList) {
       return;
@@ -330,7 +329,12 @@ export default class BlogPost extends React.Component {
       blogPostTextElements.splice(articleListPosition, 0, siblingArticlesList);
       content.splice(content.length - 1, 0, nextArticleLink);
     }
-    if (articleFootNote && printEdition) {
+  }
+
+  addArticleFootNote(content, articleFootNote) {
+    let blogPostTextElements = null;
+    if (articleFootNote) {
+      blogPostTextElements = this.filterBlogPostTextElements(content);
       blogPostTextElements.push(articleFootNote);
     }
   }
@@ -400,6 +404,7 @@ export default class BlogPost extends React.Component {
       printEdition,
       secondaryList,
       secondaryListPosition,
+      articleFootNote,
     } = this.props;
     const siblingsListTitle = this.props.sectionName;
     const elementClassName = showSiblingArticlesList && this.props.classNameModifier ?
@@ -457,6 +462,9 @@ export default class BlogPost extends React.Component {
       </div>
     );
     this.moveBottomMobileAd(content);
+    if (printEdition && articleFootNote) {
+      this.addArticleFootNote(content, articleFootNote);
+    }
     const TitleComponent = this.props.TitleComponent;
     const articleHeader = showSiblingArticlesList ? (
       <span className={`blog-post__siblings-list-header ${ elementClassName }`}>

--- a/src/index.js
+++ b/src/index.js
@@ -456,8 +456,8 @@ export default class BlogPost extends React.Component {
     );
     const blogPostText = this.filterBlogPostTextElements(content);
     this.moveBottomMobileAd(content, blogPostText);
-    if (printEdition && articleFootNote) {
-      this.addArticleFootNote(blogPostText, articleFootNote);
+    if (printEdition && articleFootNote && blogPostText) {
+      blogPostText.push(articleFootNote);
     }
     const TitleComponent = this.props.TitleComponent;
     const articleHeader = showSiblingArticlesList ? (

--- a/test/index.js
+++ b/test/index.js
@@ -4,11 +4,9 @@ import BlogPost, { generateBlogPostFlyTitle } from '../src';
 import MobileDetect from 'mobile-detect';
 import React from 'react';
 import chai from 'chai';
-import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';
-import createFragment from 'react-addons-create-fragment'
 chai.use(chaiEnzyme()).should();
 chai.use(sinonChai);
 
@@ -22,10 +20,10 @@ const requiredProps = {
   flyTitle: 'Required flyTitle',
   section: 'Required section',
   text: [
-    "paragraph 1",
-    "paragraph 2",
-    "paragraph 3",
-    "paragraph 4",
+    'paragraph 1',
+    'paragraph 2',
+    'paragraph 3',
+    'paragraph 4',
   ],
   title: 'Required title',
   type: 'blog',
@@ -41,62 +39,19 @@ const requiredProps = {
   TitleComponent: ({ flyTitle, title }) => (<div className="test-title-component">test: {flyTitle} {title}</div>),
 };
 
-const otherProps = {
-  flyTitle: 'Other flyTitle',
-  section: 'Other section',
-  text: [
-    "paragraph 1",
-    "paragraph 2",
-    "paragraph 3",
-    "paragraph 4",
-  ],
-  title: 'Other title',
-  type: 'blog',
-  id: 'test blog',
-  publicationDate: '02/03/04',
-  commentCount: 10,
-  commentsUri: 'http://google.com',
-  viewCommentsLabel: 'foo',
-  commentStatus: 'readwrite',
+const siblingListProps = {
   issueSiblingsList: [
-    {key: '1', flyTitle: 'flytitle1', title: 'title1', webURL: 'www.1.com'},
-    {key: '2', flyTitle: 'flytitle2', title: 'title2', webURL: 'www.2.com'},
-    {key: '3', flyTitle: 'flytitle3', title: 'title3', webURL: 'www.3.com'},
+    { key: '1', flyTitle: 'flytitle1', title: 'title1', webURL: 'www.1.com' },
+    { key: '2', flyTitle: 'flytitle2', title: 'title2', webURL: 'www.2.com' },
+    { key: '3', flyTitle: 'flytitle3', title: 'title3', webURL: 'www.3.com' },
   ],
   showSiblingArticlesList: true,
   elementClassName: 'blog-post__classname',
   sectionName: 'Special report',
   sideText: 'More in this report',
-  TitleComponent: ({ flyTitle, title }) => (<div className="test-title-component">test: {flyTitle} {title}</div>),
-}
-
-const moreProps = {
-  flyTitle: 'Required flyTitle',
-  section: 'Required section',
-  text: [
-    createFragment({children: ['paragraph1']}),
-    createFragment({children: ['paragraph2']}),
-    createFragment({children: ['paragraph3']}),
-  ],
-  title: 'Required title',
-  type: 'blog',
-  id: 'test blog',
-  publicationDate: '01/02/03',
-  commentCount: 10,
-  commentsUri: 'http://google.com',
-  viewCommentsLabel: 'foo',
-  commentStatus: 'readwrite',
-  elementClassName: 'blog-post__classname',
-  sectionName: 'Section name',
-  secondaryListModifier: 'modifier',
-  TitleComponent: ({ flyTitle, title }) => (<div className="test-title-component">test: {flyTitle} {title}</div>),
-  articleFootNote: (<div className='articleFootNote'>articleFootNote</div>),
-  printEdition: true,
-}
+};
 
 const mountComponentWithProps = mountComponent(requiredProps);
-const mountComponentWithOtherProps = mountComponent(otherProps)
-const mountComponentWithMoreProps = mountComponent(moreProps)
 describe('BlogPost', () => {
   it('is compatible with React.Component', () => {
     BlogPost.should.be.a('function')
@@ -134,7 +89,14 @@ describe('BlogPost', () => {
     });
 
     it('should render a footnote if provided', () => {
-      const blog = mountComponentWithMoreProps();
+      Object.assign(
+        requiredProps,
+        {
+          articleFootNote: (<div className="articleFootNote" key="footNote">articleFootNote</div>),
+          printEdition: true,
+        }
+      );
+      const blog = mountComponentWithProps();
       blog.find('.blog-post__text').should.have.exactly(1).descendants('.articleFootNote');
     });
 
@@ -143,11 +105,16 @@ describe('BlogPost', () => {
   describe('Blog post siblings list', () => {
     let post = null;
     before(() => {
-      post = mountComponentWithOtherProps();
+      // Resetting requiredProps before running these tests.
+      Reflect.deleteProperty(requiredProps, 'articleFootNote');
+      Reflect.deleteProperty(requiredProps, 'printEdition');
+      requiredProps.text.pop();
+      Object.assign(requiredProps, siblingListProps);
+      post = mountComponentWithProps();
     });
 
     it('renders sideText given from props', () => {
-      post.find('.blog-post__side-text').should.have.text(otherProps.sideText);
+      post.find('.blog-post__side-text').should.have.text(requiredProps.sideText);
     });
 
     it('renders a list of siblings', () => {
@@ -158,25 +125,28 @@ describe('BlogPost', () => {
 
   describe('Generate blog post flyTitle', () => {
     it('should generate just the report title if flytitle is the same', () => {
-      const blogPostFlyTitle = generateBlogPostFlyTitle(true, "report title", "report title");
-      blogPostFlyTitle.should.equal("report title");
+      const blogPostFlyTitle = generateBlogPostFlyTitle(true, 'report title', 'report title');
+      blogPostFlyTitle.should.equal('report title');
     });
 
     it('should return the report title and flyTitle if they are different', () => {
-      const blogPostFlyTitle = generateBlogPostFlyTitle(true, "report title", "flyTitle");
-      blogPostFlyTitle.should.equal("report title: flyTitle");
-    })
+      const blogPostFlyTitle = generateBlogPostFlyTitle(true, 'report title', 'flyTitle');
+      blogPostFlyTitle.should.equal('report title: flyTitle');
+    });
   });
 
   describe('Comments', () => {
     it('renders the comments (#comments > 0)', () => {
+      // Resetting requiredProps before running these tests.
+      Reflect.deleteProperty(requiredProps, 'issueSiblingsList');
+      Reflect.deleteProperty(requiredProps, 'showSiblingArticlesList');
       const post = mountComponentWithProps({
         commentCount: 10,
-        viewCommentsLabel: 'foo'
+        viewCommentsLabel: 'foo',
       });
       post.should.have.exactly(2).descendants('.blog-post__comments');
       const comments = post.find('.blog-post__comments');
-      comments.forEach(node => node.should.have.attr('href', requiredProps.commentsUri));
+      comments.forEach((node) => node.should.have.attr('href', requiredProps.commentsUri));
       post.find('.blog-post__comments-label').should.have.text('foo');
     });
 
@@ -184,7 +154,7 @@ describe('BlogPost', () => {
       const post = mountComponentWithProps({ commentCount: 0 });
       post.should.have.exactly(2).descendants('.blog-post__comments');
       const comments = post.find('.blog-post__comments');
-      comments.forEach(node => node.should.have.attr('href', requiredProps.commentsUri));
+      comments.forEach((node) => node.should.have.attr('href', requiredProps.commentsUri));
       post.find('.blog-post__comments-label').should.have.text('Be the first to comment');
     });
 
@@ -259,9 +229,9 @@ describe('BlogPost', () => {
       <div key="1" className="paragraph">paragraph 1</div>,
       <div key="2" className="inline-ad">inline advert 1</div>,
       <div key="3" className="paragraph">paragraph 2</div>,
-      <div key="4" className="inline-ad">inline advert 2</div>
-    ]
-    const blogPostText = mountComponentWithProps({ text: text }).find('.blog-post__text');
+      <div key="4" className="inline-ad">inline advert 2</div>,
+    ];
+    const blogPostText = mountComponentWithProps({ text }).find('.blog-post__text');
     blogPostText.should.have.exactly(2).descendants('.paragraph');
     blogPostText.contains(
       <div key="2" className="inline-ad">inline advert 1</div>
@@ -320,23 +290,21 @@ describe('BlogPost', () => {
 
       it('should feature the twitter and facebook share buttons', () => {
         const post = mountComponentWithProps();
-        post.find('.share__icon--twitter').find('a').forEach(function (node) {
+        post.find('.share__icon--twitter').find('a').forEach((node) => {
           node.should.have.attr('href', 'https://twitter.com/intent/tweet?url=');
         });
-        post.find('.share__icon--facebook').find('a').forEach(function (node) {
+        post.find('.share__icon--facebook').find('a').forEach((node) => {
           node.should.have.attr('href', 'http://www.facebook.com/sharer/sharer.php?u=');
         });
       });
 
       it('should show the other providers when clicking on the share button', () => {
         const post = mountComponentWithProps();
-
-        post.find('.blog-post__toggle-share').forEach(function (node) {
+        post.find('.blog-post__toggle-share').forEach((node) => {
           node.should.have.className('balloon--not-visible');
           node.find('a.balloon__link').simulate('click');
           node.should.have.className('balloon--visible');
           const balloonContentNode = node.find('.balloon-content');
-
           balloonContentNode.should.have.exactly(1).descendants('.share__icon--linkedin');
           balloonContentNode.find('.share__icon--linkedin').find('a')
             .should.have.attr('href', 'https://www.linkedin.com/cws/share?url=');
@@ -365,18 +333,17 @@ describe('BlogPost', () => {
 
       it('shows some share providers outside the more menu', () => {
         const post = mountComponentWithProps();
-        post.find('.share__icon--twitter').find('a').forEach(function (node) {
+        post.find('.share__icon--twitter').find('a').forEach((node) => {
           node.should.have.attr('href', 'https://twitter.com/intent/tweet?url=');
         });
-        post.find('.share__icon--facebook').find('a').forEach(function (node) {
+        post.find('.share__icon--facebook').find('a').forEach((node) => {
           node.should.have.attr('href', 'http://www.facebook.com/sharer/sharer.php?u=');
         });
       });
 
       it('should show the mobile providers', () => {
         const post = mountComponentWithProps();
-
-        post.find('.blog-post__toggle-share-mobile').forEach(function (node) {
+        post.find('.blog-post__toggle-share-mobile').forEach((node) => {
           const balloonContentNode = node.find('.balloon-content');
           balloonContentNode.should.have.exactly(1).descendants('.share__icon--linkedin');
           balloonContentNode.find('.share__icon--linkedin').find('a')

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';
+import createFragment from 'react-addons-create-fragment'
 chai.use(chaiEnzyme()).should();
 chai.use(sinonChai);
 
@@ -69,8 +70,33 @@ const otherProps = {
   TitleComponent: ({ flyTitle, title }) => (<div className="test-title-component">test: {flyTitle} {title}</div>),
 }
 
+const moreProps = {
+  flyTitle: 'Required flyTitle',
+  section: 'Required section',
+  text: [
+    createFragment({children: ['paragraph1']}),
+    createFragment({children: ['paragraph2']}),
+    createFragment({children: ['paragraph3']}),
+  ],
+  title: 'Required title',
+  type: 'blog',
+  id: 'test blog',
+  publicationDate: '01/02/03',
+  commentCount: 10,
+  commentsUri: 'http://google.com',
+  viewCommentsLabel: 'foo',
+  commentStatus: 'readwrite',
+  elementClassName: 'blog-post__classname',
+  sectionName: 'Section name',
+  secondaryListModifier: 'modifier',
+  TitleComponent: ({ flyTitle, title }) => (<div className="test-title-component">test: {flyTitle} {title}</div>),
+  articleFootNote: (<div className='articleFootNote'>articleFootNote</div>),
+  printEdition: true,
+}
+
 const mountComponentWithProps = mountComponent(requiredProps);
 const mountComponentWithOtherProps = mountComponent(otherProps)
+const mountComponentWithMoreProps = mountComponent(moreProps)
 describe('BlogPost', () => {
   it('is compatible with React.Component', () => {
     BlogPost.should.be.a('function')
@@ -105,6 +131,11 @@ describe('BlogPost', () => {
 
     it('renders the section name', () => {
       post.find('.blog-post__section').should.have.text(requiredProps.section);
+    });
+
+    it('should render a footnote if provided', () => {
+      const blog = mountComponentWithMoreProps();
+      blog.find('.blog-post__text').should.have.exactly(1).descendants('.articleFootNote');
     });
 
   });


### PR DESCRIPTION
https://jira.economist.com/browse/WP-890

For some odd reason when I first implemented this functionality of adding the small footnote at the bottom of articles I put it in the functionality for special reports only. This PR moves it so that it appears in all articles that need the footNote.