### PR TITLE
fix: WP-917 E.COM | As a reader I want to leverage the single-page application (SPA) when I click on the section link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ export default class BlogPost extends React.Component {
       id: React.PropTypes.string.isRequired,
       publicationDate: React.PropTypes.string.isRequired,
       TitleComponent: React.PropTypes.func.isRequired,
-      LinkComponent: React.PropTypes.func.isRequired,
+      LinkComponent: React.PropTypes.func,
       rubric: React.PropTypes.string,
       dateTime: React.PropTypes.instanceOf(Date),
       dateString: React.PropTypes.string,
@@ -200,15 +200,15 @@ export default class BlogPost extends React.Component {
   }
 
   addBlogPostSection(sectionDateAuthor, section, sectionUrl) {
-    const { LinkComponent: Link } = this.props;
+    const { LinkComponent = 'a' } = this.props;
     if (section) {
       if (sectionUrl && !/^(\w+:)?\/\//.test(sectionUrl)) {
         sectionUrl = urlJoin('/', sectionUrl);
       }
       const blogPostSection = sectionUrl ? (
-        <Link href={sectionUrl} className="blog-post__section-link">
+        <LinkComponent href={sectionUrl} className="blog-post__section-link">
           {section}
-        </Link>
+        </LinkComponent>
       ) : section;
       return sectionDateAuthor.concat(
         <BlogPostSection key="blog-post__section" section={blogPostSection} />

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ export default class BlogPost extends React.Component {
       id: React.PropTypes.string.isRequired,
       publicationDate: React.PropTypes.string.isRequired,
       TitleComponent: React.PropTypes.func.isRequired,
+      LinkComponent: React.PropTypes.func.isRequired,
       rubric: React.PropTypes.string,
       dateTime: React.PropTypes.instanceOf(Date),
       dateString: React.PropTypes.string,
@@ -199,14 +200,15 @@ export default class BlogPost extends React.Component {
   }
 
   addBlogPostSection(sectionDateAuthor, section, sectionUrl) {
+    const { LinkComponent: Link } = this.props;
     if (section) {
       if (sectionUrl && !/^(\w+:)?\/\//.test(sectionUrl)) {
         sectionUrl = urlJoin('/', sectionUrl);
       }
       const blogPostSection = sectionUrl ? (
-        <a href={sectionUrl} className="blog-post__section-link">
+        <Link href={sectionUrl} className="blog-post__section-link">
           {section}
-        </a>
+        </Link>
       ) : section;
       return sectionDateAuthor.concat(
         <BlogPostSection key="blog-post__section" section={blogPostSection} />

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,7 @@ const requiredProps = {
   sectionName: 'Section name',
   secondaryListModifier: 'modifier',
   TitleComponent: ({ flyTitle, title }) => (<div className="test-title-component">test: {flyTitle} {title}</div>),
+  LinkComponent: ({ href, className }) => (<a className={className} href={href}>{requiredProps.section}</a>)
 };
 
 const siblingListProps = {


### PR DESCRIPTION
https://jira.economist.com/browse/WP-917

Test strategy:
- Open article
- Open network tab in console and filter by `Doc`.
- Click on section link
- Observe no HTTP requests made for that section, for example:
This article belonging to the section "Europe": http://localhost:3000/news/europe/21717056-italys-ex-prime-minister-taking-another-big-bet-matteo-renzi-plans-quit-his-job-and-win-it
You should observe no http request made for a doc named "europe".